### PR TITLE
One Hundred Error in Turkish

### DIFF
--- a/converters/tr.js
+++ b/converters/tr.js
@@ -36,9 +36,9 @@ TrConverter.prototype.convertToText = function (num, options) {
       splitValues.push(module.exports.convertToText(splitNum))
     } else {
       if (splitNum.length === 3 && ones[splitNum.charAt(0)]) {
-        const hundredNum = splitNum.charAt(0);
+        const hundredNum = splitNum.charAt(0)
         if (hundredNum > 1) {
-          splitValues.push(ones[hundredNum]);
+          splitValues.push(ones[hundredNum])
         }
         splitValues.push('Yüz')
       } if (splitNum.length >= 2) {

--- a/converters/tr.js
+++ b/converters/tr.js
@@ -36,7 +36,10 @@ TrConverter.prototype.convertToText = function (num, options) {
       splitValues.push(module.exports.convertToText(splitNum))
     } else {
       if (splitNum.length === 3 && ones[splitNum.charAt(0)]) {
-        splitValues.push(ones[splitNum.charAt(0)])
+        const hundredNum = splitNum.charAt(0);
+        if (hundredNum > 1) {
+          splitValues.push(ones[hundredNum]);
+        }
         splitValues.push('Yüz')
       } if (splitNum.length >= 2) {
         if (splitNum.substr(-2, 1) === '1') {


### PR DESCRIPTION
Fixed One Hundred error in Turkish.

In English:
200: Two Hundred
100: One Hundred

In Turkish
200: İki Yüz
100: Yüz

There is no "one" before "hundred" in Turkish.